### PR TITLE
'Read more' buttons on portfolio projects display properly.

### DIFF
--- a/app/assets/styles/modules/page-modules/portfolio/_project.scss
+++ b/app/assets/styles/modules/page-modules/portfolio/_project.scss
@@ -155,6 +155,7 @@
 
 		&__shade {
 			position: absolute;
+			z-index: $layer6;
 			bottom: 0;
 			right: 0;
 			left: 0;


### PR DESCRIPTION
The Problem: the 'read more' buttons overlaying the professional portfolio projects were displayed behind the text.

The cause came from confusion around the HTML structure and the various `absolutely` positioned elements, or `flex` items reordered, 
meanwhile, the `shade` markup (which contains the button) is `absolutely` positioned so any z-index applied to children of the shade container does not have the expected effect. 

The solution was to add a simple `z-index` to the shade layer, not the button itself.