### PR TITLE
Fix smooth scroll buttons on the Portfolio page

### DIFF
--- a/app/assets/scripts/App.js
+++ b/app/assets/scripts/App.js
@@ -57,7 +57,9 @@ function loadPortfolioPageJS() {
 			hideShadeBtn: allHideShadeButtons[i],
 			shadedArticle: allShadedArticles[i],
 		});
-		new SmoothScroll(document.getElementById(`${allShowShadeButtons[i].getAttribute("id")}`));
+		console.log("_______SHADE ELEMENT: ", allShowShadeButtons[i]);
+		new SmoothScroll(allShowShadeButtons[i]);
+		// new SmoothScroll(document.getElementById(`${allShowShadeButtons[i].getAttribute("id")}`));
 	}
 
 	shadeButtonGroups.forEach((group) => {

--- a/app/assets/scripts/App.js
+++ b/app/assets/scripts/App.js
@@ -57,7 +57,6 @@ function loadPortfolioPageJS() {
 			hideShadeBtn: allHideShadeButtons[i],
 			shadedArticle: allShadedArticles[i],
 		});
-		console.log("_______SHADE ELEMENT: ", allShowShadeButtons[i]);
 		new SmoothScroll(allShowShadeButtons[i]);
 		// new SmoothScroll(document.getElementById(`${allShowShadeButtons[i].getAttribute("id")}`));
 	}

--- a/app/portfolio.html
+++ b/app/portfolio.html
@@ -406,9 +406,6 @@
 					</div>
 				</article>
 
-				<!-- <hr class="project__divider" id="materials-proj-scroll-anchor" /> -->
-				<!-- <span id="materials-proj-scroll-anchor"></span> -->
-
 				<article class="project project--professional" id="materials-proj-scroll-anchor">
 					<div class="project__text">
 						<h3 class="project__heading">Materials Testing Online Ordering System</h3>
@@ -497,10 +494,10 @@
 					</div>
 				</article>
 
-				<hr class="project__divider" id="salon-proj-scroll-anchor" />
+				<!-- <hr class="project__divider" id="salon-proj-scroll-anchor" /> -->
 
 				<article class="project project--professional" id="salon-business">
-					<div class="project__text">
+					<div class="project__text" id="salon-proj-scroll-anchor">
 						<h3 class="project__heading">Business Administration and Management Applications</h3>
 						<h4>Regional Franchised Salon Business</h4>
 						<p>


### PR DESCRIPTION
**The Problem**
Only one of the buttons using smooth scroll on the Portfolio page was working correctly. Three of them were a 'show less' button smooth scrolling back to the top of the article and one was an inline link scrolling to the 'side projects' section of the page.

**The Culprit**
This was a combination of a few things:
- jQuery methods still being called on dom elements.
- a variety of dom elements being passed to the `SmoothScroll` class
- a variety of formatting based on the element passed in
- `display: none` `<hr />` tags attempting to serve as anchor links

**The Solution**
- Transition jQuery dom-manipulation methods over to their vanilla JS counterparts.
- Add the `data-href` properties to any HTML element being passed in to the `SmoothScroll`
- Update `SmoothScroll` to use this new property
- Standardize this usage across the HTML pages and elements requiring `SmoothScroll`
- Standardize and place correct scroll anchor links.

Most of these changes came over time through different branches and pull requests that were loosely related to other things.